### PR TITLE
groovy-mode 1.0.0

### DIFF
--- a/Formula/groovy-mode.rb
+++ b/Formula/groovy-mode.rb
@@ -3,7 +3,16 @@ require File.expand_path("../../Homebrew/emacs_formula", __FILE__)
 class GroovyMode < EmacsFormula
   desc "Modes for Groovy and Groovy-related technology"
   homepage "https://github.com/Groovy-Emacs-Modes/groovy-emacs-modes"
+  url "https://github.com/Groovy-Emacs-Modes/groovy-emacs-modes/archive/v-1.0.0.tar.gz"
+  sha256 "601444423056310f5b043c8f6006cec936f2092226ea45717a648b9bf05e4615"
   head "https://github.com/Groovy-Emacs-Modes/groovy-emacs-modes.git"
+
+  stable do
+    patch do
+      url "https://github.com/Groovy-Emacs-Modes/groovy-emacs-modes/commit/792b0c5a72f7500c8e07f37b77b96fd1f91ac61b.diff"
+      sha256 "163a42603f7c4e178359b4310ce1fa7d9e9011304f2b2f32d4e884d3ed16f0a8"
+    end
+  end
 
   depends_on :emacs => "22.1"
 


### PR DESCRIPTION
This is the first stable release of groovy-mode. Previously it was HEAD-only.