### PR TITLE
groovy-mode: install license file in prefix instead of doc directory

### DIFF
--- a/Formula/groovy-mode.rb
+++ b/Formula/groovy-mode.rb
@@ -22,7 +22,7 @@ class GroovyMode < EmacsFormula
     byte_compile el_array
     elisp.install el_array, Dir["*.elc"]
 
-    doc.install "gplv2.txt"
+    prefix.install "gplv2.txt"
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
This changes where `gplv2.txt` is installed, as I brought up [here](https://github.com/Homebrew/homebrew-emacs/pull/277#discussion_r61428713).
