### PR TITLE
yasnippet 0.10.0

### DIFF
--- a/Formula/yasnippet.rb
+++ b/Formula/yasnippet.rb
@@ -3,18 +3,8 @@ require File.expand_path("../../Homebrew/emacs_formula", __FILE__)
 class Yasnippet < EmacsFormula
   desc "Emacs template system"
   homepage "https://github.com/capitaomorte/yasnippet"
-
-  stable do
-    url "https://github.com/capitaomorte/yasnippet.git",
-        :tag => "0.9.1",
-        :revision => "6aeccce2f17aca6a59a2790ec08680d52c03f6c0"
-
-    patch do
-      url "https://github.com/capitaomorte/yasnippet/commit/78fe979b7b4634ce2ef4d89363f1e1471a901230.diff"
-      sha256 "6f12d833388920a3812ced24c37d1db3e9b0b9e35c65b55cef1befc29237ae50"
-    end
-  end
-
+  url "https://elpa.gnu.org/packages/yasnippet-0.10.0.tar"
+  sha256 "bb75c4ead91547cc4d178ad522a9f0f23eadd553d9924cdfefcace3c4e04076e"
   head "https://github.com/capitaomorte/yasnippet.git"
 
   option "with-htmlize", "Build HTML docs with htmlize"
@@ -24,8 +14,8 @@ class Yasnippet < EmacsFormula
   depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
 
   def install
-    byte_compile "yasnippet.el"
     ert_run_tests "yasnippet-tests.el"
+    byte_compile "yasnippet.el"
 
     if build.with? "htmlize"
       system "rake", "doc[#{Formula["htmlize"].opt_elisp}]"
@@ -33,7 +23,7 @@ class Yasnippet < EmacsFormula
     end
 
     elisp.install Dir["*.el"], Dir["*.elc"]
-    (prefix/"contrib").install "snippets", "yasmate"
+    (prefix/"contrib").install "snippets"
   end
 
   def caveats


### PR DESCRIPTION
Switch to ELPA tarball since a yasmate submodule fails fsck:

```
Cloning into '/Users/cat/Library/Caches/Homebrew/yasnippet--git/yasmate/bundles/rails-tmbundle'...
error: object 060551a1f77fa67bad78c9a2076d934a8d858c88: zeroPaddedFilemode: contains zero-padded file modes
fatal: Error in object
fatal: index-pack failed
fatal: clone of 'https://github.com/textmate/ruby-on-rails-tmbundle.git' into submodule path '/Users/cat/Library/Caches/Homebrew/yasnippet--git/yasmate/bundles/rails-tmbundle' failed
```