### PR TITLE
Fix escaped backslashes in rust-mode's caveat code

### DIFF
--- a/Formula/rust-mode.rb
+++ b/Formula/rust-mode.rb
@@ -20,7 +20,7 @@ class RustMode < EmacsFormula
     Add the following to your init file:
 
     (autoload 'rust-mode "rust-mode" nil t)
-    (add-to-list 'auto-mode-alist '("\\.rs\\'" . rust-mode))
+    (add-to-list 'auto-mode-alist '("\\\\.rs\\\\'" . rust-mode))
   EOS
   end
 

--- a/Formula/rust-mode.rb
+++ b/Formula/rust-mode.rb
@@ -16,14 +16,6 @@ class RustMode < EmacsFormula
     doc.install "README.md"
   end
 
-  def caveats; <<-EOS.undent
-    Add the following to your init file:
-
-    (autoload 'rust-mode "rust-mode" nil t)
-    (add-to-list 'auto-mode-alist '("\\\\.rs\\\\'" . rust-mode))
-  EOS
-  end
-
   test do
     (testpath/"test.el").write <<-EOS.undent
       (add-to-list 'load-path "#{share}/emacs/site-lisp/rust-mode")


### PR DESCRIPTION
I installed [rust-mode](https://github.com/rust-lang/rust-mode/) with Homebrew, and added the Lisp snippet mentioned in the caveat to my `init.el`:

```lisp
(autoload 'rust-mode "rust-mode" nil t)
(add-to-list 'auto-mode-alist '("\.rs\'" . rust-mode))
```
This didn't do anything until I looked up `auto-mode-alist` in [the documentation](https://www.emacswiki.org/emacs/AutoModeAlist). Their example used two quotes in the file-extension... surely enough, using two quotes enabled Emacs to "recognise" an `.rs` file.