### PR TITLE
Emacs.version: use Version instead of floats

### DIFF
--- a/Formula/ag-emacs.rb
+++ b/Formula/ag-emacs.rb
@@ -11,7 +11,7 @@ class AgEmacs < EmacsFormula
   depends_on "the_silver_searcher"
   depends_on "homebrew/emacs/dash-emacs"
   depends_on "homebrew/emacs/s-emacs"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile "ag.el"

--- a/Formula/aggressive-indent.rb
+++ b/Formula/aggressive-indent.rb
@@ -8,7 +8,7 @@ class AggressiveIndent < EmacsFormula
   head "https://github.com/Malabarba/aggressive-indent-mode.git"
 
   depends_on :emacs => "24.1"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     mv "aggressive-indent-#{version}.el", "aggressive-indent.el" if build.stable?

--- a/Formula/ansi-emacs.rb
+++ b/Formula/ansi-emacs.rb
@@ -10,7 +10,7 @@ class AnsiEmacs < EmacsFormula
   depends_on :emacs
   depends_on "homebrew/emacs/dash-emacs"
   depends_on "homebrew/emacs/s-emacs"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile "ansi.el"

--- a/Formula/anzu-mode.rb
+++ b/Formula/anzu-mode.rb
@@ -8,7 +8,7 @@ class AnzuMode < EmacsFormula
   head "https://github.com/syohex/emacs-anzu.git"
 
   depends_on :emacs => "24.1"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile "anzu.el"

--- a/Formula/async-emacs.rb
+++ b/Formula/async-emacs.rb
@@ -8,7 +8,7 @@ class AsyncEmacs < EmacsFormula
   head "https://github.com/jwiegley/emacs-async.git"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile Dir["*.el"]

--- a/Formula/auto-complete.rb
+++ b/Formula/auto-complete.rb
@@ -20,7 +20,7 @@ class AutoComplete < EmacsFormula
 
   depends_on :emacs => "24.1"
   depends_on "homebrew/emacs/popup"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   depends_on "homebrew/emacs/haskell-mode" if build.with? "haskell"
   depends_on "homebrew/emacs/helm" if build.with? "helm"

--- a/Formula/avy.rb
+++ b/Formula/avy.rb
@@ -8,7 +8,7 @@ class Avy < EmacsFormula
   head "https://github.com/abo-abo/avy.git"
 
   depends_on :emacs => "24.1"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     system "make", "compile"

--- a/Formula/beacon-mode.rb
+++ b/Formula/beacon-mode.rb
@@ -8,7 +8,7 @@ class BeaconMode < EmacsFormula
   head "https://github.com/Malabarba/beacon.git"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/seq" if Emacs.version < 25
+  depends_on "homebrew/emacs/seq" if Emacs.version < Version.create("25")
 
   def install
     mv "beacon-#{version}.el", "beacon.el" if build.stable?

--- a/Formula/bundler-emacs.rb
+++ b/Formula/bundler-emacs.rb
@@ -17,7 +17,7 @@ class BundlerEmacs < EmacsFormula
 
   depends_on :emacs
   depends_on "homebrew/emacs/inf-ruby"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile "bundler.el"

--- a/Formula/chess-emacs.rb
+++ b/Formula/chess-emacs.rb
@@ -9,7 +9,7 @@ class ChessEmacs < EmacsFormula
        :branch => "externals/chess"
 
   depends_on :emacs => "24.1"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     system "make", "test" if build.head?

--- a/Formula/cider.rb
+++ b/Formula/cider.rb
@@ -14,7 +14,7 @@ class Cider < EmacsFormula
   depends_on "homebrew/emacs/dash-emacs"
   depends_on "homebrew/emacs/pkg-info"
   depends_on "homebrew/emacs/queue-emacs"
-  depends_on "homebrew/emacs/seq" if Emacs.version < 25
+  depends_on "homebrew/emacs/seq" if Emacs.version < Version.create("25")
   depends_on "homebrew/emacs/spinner-emacs"
 
   def install

--- a/Formula/circe.rb
+++ b/Formula/circe.rb
@@ -8,7 +8,7 @@ class Circe < EmacsFormula
   head "https://github.com/jorgenschaefer/circe.git"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile Dir["*.el"]

--- a/Formula/cl-lib.rb
+++ b/Formula/cl-lib.rb
@@ -17,7 +17,7 @@ class ClLib < EmacsFormula
                                              Dir["*.elc"]
   end
 
-  if Emacs.version >= 24.3
+  if Emacs.version >= Version.create("24.3")
     def caveats; <<-EOS.undent
       Warning: Emacs 24.3 and higher includes cl-lib
 

--- a/Formula/cloc-emacs.rb
+++ b/Formula/cloc-emacs.rb
@@ -6,7 +6,7 @@ class ClocEmacs < EmacsFormula
   head "https://github.com/cosmicexplorer/cloc-emacs.git"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile "cloc.el"

--- a/Formula/coffee-mode.rb
+++ b/Formula/coffee-mode.rb
@@ -8,7 +8,7 @@ class CoffeeMode < EmacsFormula
   head "https://github.com/defunkt/coffee-mode.git"
 
   depends_on :emacs => "24.1"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     ert_run_tests Dir["test/*.el"]

--- a/Formula/commander-emacs.rb
+++ b/Formula/commander-emacs.rb
@@ -11,7 +11,7 @@ class CommanderEmacs < EmacsFormula
   depends_on "homebrew/emacs/dash-emacs"
   depends_on "homebrew/emacs/f-emacs"
   depends_on "homebrew/emacs/s-emacs"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile "commander.el"

--- a/Formula/company-mode.rb
+++ b/Formula/company-mode.rb
@@ -13,7 +13,7 @@ class CompanyMode < EmacsFormula
   option "with-web", "Install web templating backend"
 
   depends_on :emacs => "24.1"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   if build.with? "web"
     depends_on "homebrew/emacs/dash-emacs"

--- a/Formula/darkroom-mode.rb
+++ b/Formula/darkroom-mode.rb
@@ -8,7 +8,7 @@ class DarkroomMode < EmacsFormula
   head "https://github.com/capitaomorte/darkroom.git"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile "darkroom.el"

--- a/Formula/dbus-codegen.rb
+++ b/Formula/dbus-codegen.rb
@@ -8,7 +8,7 @@ class DbusCodegen < EmacsFormula
   head "https://github.com/ueno/dbus-codegen-el.git"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     mv "dbus-codegen-#{version}.el", "dbus-codegen.el" if build.stable?

--- a/Formula/debbugs.rb
+++ b/Formula/debbugs.rb
@@ -7,7 +7,7 @@ class Debbugs < EmacsFormula
   sha256 "189f14f7c60c925c57fbae34ee9b0020a0e34e0ae08e2d601c02564a5c1c871f"
 
   depends_on :emacs => "22.1"
-  depends_on "homebrew/emacs/soap-client-emacs" if Emacs.version < 24.1
+  depends_on "homebrew/emacs/soap-client-emacs" if Emacs.version < Version.create("24.1")
 
   def install
     byte_compile Dir["*.el"]

--- a/Formula/diff-hl.rb
+++ b/Formula/diff-hl.rb
@@ -8,7 +8,7 @@ class DiffHl < EmacsFormula
   head "https://github.com/dgutov/diff-hl.git"
 
   depends_on :emacs => "24.1"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile Dir["*.el"]

--- a/Formula/easy-kill.rb
+++ b/Formula/easy-kill.rb
@@ -8,7 +8,7 @@ class EasyKill < EmacsFormula
   head "https://github.com/leoliu/easy-kill.git"
 
   depends_on :emacs => "24.1"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     system "make", "test"

--- a/Formula/editorconfig-emacs.rb
+++ b/Formula/editorconfig-emacs.rb
@@ -13,7 +13,7 @@ class EditorconfigEmacs < EmacsFormula
   depends_on :emacs => "24.1"
   depends_on "cmake" => :build
   depends_on "editorconfig" => :recommended
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     ENV["LC_ALL"] = "en_US.UTF-8"

--- a/Formula/el-x.rb
+++ b/Formula/el-x.rb
@@ -8,7 +8,7 @@ class ElX < EmacsFormula
   head "https://github.com/sigma/el-x.git"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     system "make"

--- a/Formula/elisp-bug-hunter.rb
+++ b/Formula/elisp-bug-hunter.rb
@@ -8,8 +8,8 @@ class ElispBugHunter < EmacsFormula
   head "https://github.com/Malabarba/elisp-bug-hunter.git"
 
   depends_on :emacs => "24.1"
-  depends_on "homebrew/emacs/seq" if Emacs.version < 25
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/seq" if Emacs.version < Version.create("25")
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     if build.stable?

--- a/Formula/enwc.rb
+++ b/Formula/enwc.rb
@@ -8,7 +8,7 @@ class Enwc < EmacsFormula
   head "http://bzr.savannah.nongnu.org/r/enwc/trunk", :using => :bzr
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     if build.stable?

--- a/Formula/ert-runner.rb
+++ b/Formula/ert-runner.rb
@@ -15,7 +15,7 @@ class ErtRunner < EmacsFormula
   depends_on "homebrew/emacs/f-emacs"
   depends_on "homebrew/emacs/s-emacs"
   depends_on "homebrew/emacs/shut-up"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile Dir["*.el"]

--- a/Formula/flycheck.rb
+++ b/Formula/flycheck.rb
@@ -17,7 +17,7 @@ class Flycheck < EmacsFormula
   depends_on "homebrew/emacs/dash-emacs"
   depends_on "homebrew/emacs/let-alist"
   depends_on "homebrew/emacs/pkg-info"
-  depends_on "homebrew/emacs/seq" if Emacs.version < 25
+  depends_on "homebrew/emacs/seq" if Emacs.version < Version.create("25")
   depends_on "homebrew/emacs/haskell-mode" if build.with? "haskell"
   depends_on "homebrew/emacs/pos-tip" if build.with? "pos-tip"
 

--- a/Formula/git-messenger.rb
+++ b/Formula/git-messenger.rb
@@ -9,7 +9,7 @@ class GitMessenger < EmacsFormula
 
   depends_on :emacs
   depends_on "homebrew/emacs/popup"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile "git-messenger.el"

--- a/Formula/gnorb.rb
+++ b/Formula/gnorb.rb
@@ -8,7 +8,7 @@ class Gnorb < EmacsFormula
   head "https://github.com/girzel/gnorb.git"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile Dir["*.el"]

--- a/Formula/gnugo-emacs.rb
+++ b/Formula/gnugo-emacs.rb
@@ -10,7 +10,7 @@ class GnugoEmacs < EmacsFormula
   depends_on "homebrew/games/gnu-go"
   depends_on "homebrew/emacs/ascii-art-to-unicode"
   depends_on "homebrew/emacs/xpm-emacs"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile Dir["*.el"]

--- a/Formula/go-mode.rb
+++ b/Formula/go-mode.rb
@@ -8,7 +8,7 @@ class GoMode < EmacsFormula
   head "https://github.com/dominikh/go-mode.el"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile Dir["*.el"]

--- a/Formula/irony-mode.rb
+++ b/Formula/irony-mode.rb
@@ -8,7 +8,7 @@ class IronyMode < EmacsFormula
   head "https://github.com/Sarcasm/irony-mode.git"
 
   depends_on :emacs => "23.1"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
   depends_on "homebrew/emacs/yasnippet" => :optional
 
   depends_on "llvm" => "with-clang"

--- a/Formula/jgraph-mode.rb
+++ b/Formula/jgraph-mode.rb
@@ -7,7 +7,7 @@ class JgraphMode < EmacsFormula
   sha256 "1469d74235c64e6baa2e48183b1167bb6afc029d8e0efaace9e9e4f2658ee910"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     mv "jgraph-mode-#{version}.el", "jgraph-mode.el"

--- a/Formula/keyfreq.rb
+++ b/Formula/keyfreq.rb
@@ -8,7 +8,7 @@ class Keyfreq < EmacsFormula
   head "https://github.com/dacap/keyfreq.git"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile "keyfreq.el"

--- a/Formula/landmark-emacs.rb
+++ b/Formula/landmark-emacs.rb
@@ -7,7 +7,7 @@ class LandmarkEmacs < EmacsFormula
   sha256 "64b7a0cfcb6926ea36a248c14cf39d1d0dce2cf29449f2a07c6fdbc07ea2e157"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     mv "landmark-#{version}.el", "landmark.el"

--- a/Formula/lex-emacs.rb
+++ b/Formula/lex-emacs.rb
@@ -7,7 +7,7 @@ class LexEmacs < EmacsFormula
   sha256 "672dfebb43ea57cf05718b3bd9a72ce7967d5b3dc6f36aa18dcf8a25e688d9c4"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile Dir["*.el"]

--- a/Formula/metar-emacs.rb
+++ b/Formula/metar-emacs.rb
@@ -7,7 +7,7 @@ class MetarEmacs < EmacsFormula
   sha256 "6e6a05b4a0324cc59fba8860bddd5e2a77a88546f6ca2900efd1404ad3c1df65"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     mv "metar-#{version}.el", "metar.el"

--- a/Formula/names.rb
+++ b/Formula/names.rb
@@ -8,7 +8,7 @@ class Names < EmacsFormula
   head "https://github.com/Malabarba/names.git"
 
   depends_on :emacs => "24.1"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile Dir["*.el"]

--- a/Formula/osc-emacs.rb
+++ b/Formula/osc-emacs.rb
@@ -7,7 +7,7 @@ class OscEmacs < EmacsFormula
   sha256 "4b5bdd2c622b3b3f0ec3211c1071e88c6267de327b71c543aa32bbbeff5adf26"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     mv "osc-#{version}.el", "osc.el"

--- a/Formula/pabbrev.rb
+++ b/Formula/pabbrev.rb
@@ -8,7 +8,7 @@ class Pabbrev < EmacsFormula
   head "https://github.com/phillord/pabbrev.git"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     mv "pabbrev-#{version}.el", "pabbrev.el" if build.stable?

--- a/Formula/pandoc-mode.rb
+++ b/Formula/pandoc-mode.rb
@@ -10,7 +10,7 @@ class PandocMode < EmacsFormula
   depends_on :emacs => "24.1"
   depends_on "homebrew/emacs/dash-emacs"
   depends_on "homebrew/emacs/hydra-emacs"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile Dir["*.el"]

--- a/Formula/poker-emacs.rb
+++ b/Formula/poker-emacs.rb
@@ -7,7 +7,7 @@ class PokerEmacs < EmacsFormula
   sha256 "e0bd037d3119a203973910c1207b42eb0617db4bbea17db23107e8656a2a753d"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     mv "poker-#{version}.el", "poker.el"

--- a/Formula/popup.rb
+++ b/Formula/popup.rb
@@ -10,7 +10,7 @@ class Popup < EmacsFormula
   # only tested on 24
   depends_on :emacs => "24.1"
   depends_on "cask"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     system "make", "travis-ci", "CASK=#{Formula["cask"].bin}/cask"

--- a/Formula/powerline-emacs.rb
+++ b/Formula/powerline-emacs.rb
@@ -8,7 +8,7 @@ class PowerlineEmacs < EmacsFormula
   head "https://github.com/milkypostman/powerline.git"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile Dir["*.el"]

--- a/Formula/puppet-mode.rb
+++ b/Formula/puppet-mode.rb
@@ -8,7 +8,7 @@ class PuppetMode < EmacsFormula
   head "https://github.com/lunaryorn/puppet-mode.git"
 
   depends_on :emacs => "24.1"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
   depends_on "homebrew/emacs/pkg-info"
 
   def install

--- a/Formula/simple-httpd.rb
+++ b/Formula/simple-httpd.rb
@@ -8,7 +8,7 @@ class SimpleHttpd < EmacsFormula
   head "https://github.com/skeeto/emacs-web-server.git"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     ert_run_tests "simple-httpd-test.el"

--- a/Formula/soap-client-emacs.rb
+++ b/Formula/soap-client-emacs.rb
@@ -8,7 +8,7 @@ class SoapClientEmacs < EmacsFormula
   head "https://github.com/alex-hhh/emacs-soap-client.git"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile Dir["*.el"]

--- a/Formula/tern.rb
+++ b/Formula/tern.rb
@@ -10,7 +10,7 @@ class Tern < EmacsFormula
   depends_on "node"
   depends_on :emacs => "24"
   depends_on "homebrew/emacs/auto-complete" => :optional
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     ENV.prepend_path "PATH", "#{Formula["node"].opt_libexec}/npm/bin"

--- a/Formula/wisi-emacs.rb
+++ b/Formula/wisi-emacs.rb
@@ -7,7 +7,7 @@ class WisiEmacs < EmacsFormula
   sha256 "c335b1f368c402e7810ebf97cb52c95afd0b90807aec6d178f3beef5aef3f911"
 
   depends_on :emacs => "24.2"
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile Dir["*.el"]

--- a/Formula/xpm-emacs.rb
+++ b/Formula/xpm-emacs.rb
@@ -7,7 +7,7 @@ class XpmEmacs < EmacsFormula
   sha256 "e45281a2a361790fc1a7b17e360ab2c04a6032026d911d79448f7dde475a9361"
 
   depends_on :emacs
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     byte_compile Dir["*.el"]

--- a/Formula/yasnippet.rb
+++ b/Formula/yasnippet.rb
@@ -11,7 +11,7 @@ class Yasnippet < EmacsFormula
 
   depends_on :emacs => "23.1"
   depends_on "homebrew/emacs/htmlize" => :optional
-  depends_on "homebrew/emacs/cl-lib" if Emacs.version < 24.3
+  depends_on "homebrew/emacs/cl-lib" if Emacs.version < Version.create("24.3")
 
   def install
     ert_run_tests "yasnippet-tests.el"

--- a/Homebrew/emacs.rb
+++ b/Homebrew/emacs.rb
@@ -1,5 +1,7 @@
 module Emacs
   def self.version
-    Utils.popen_read("emacs", "--batch", "--eval", "(princ emacs-version)").to_f
+    Version.create(
+      Utils.popen_read("emacs", "-Q", "--batch", "--eval", "(princ emacs-version)")
+    )
   end
 end


### PR DESCRIPTION
Fixes version numbers with third number, like 25.1.1.