### PR TITLE
cmd/brew-emacs: Add help text

### DIFF
--- a/cmd/brew-emacs.rb
+++ b/cmd/brew-emacs.rb
@@ -1,3 +1,7 @@
+#:  * `emacs` name...:
+#:    Generate a formula for the homebrew-emacs tap for each given <name>.
+#:    Open the last formula specified in your preferred editor.
+
 raise FormulaUnspecifiedError if ARGV.empty?
 
 def template(name)


### PR DESCRIPTION
I can't say how many times I've confused the syntax of `brew emacs` with that of `brew create` and passed a URL to it by mistake.