### PR TITLE
seq: Only run tests on Emacs 25.1+

### DIFF
--- a/Formula/seq.rb
+++ b/Formula/seq.rb
@@ -22,7 +22,7 @@ class Seq < EmacsFormula
   end
 
   def install
-    ert_run_tests "tests/seq-tests.el"
+    ert_run_tests "tests/seq-tests.el" if Emacs.version >= Version.create("25.1")
     byte_compile Dir["*.el"]
     elisp.install Dir["*.el"], Dir["*.elc"]
   end


### PR DESCRIPTION
`map.el` was only introduced in Emacs 25.1 (see https://github.com/emacs-mirror/emacs/commits/7cd3d85013896dc4160f70228fc198c65a42b2e2/lisp/emacs-lisp/map.el?after=fNPYUBOJbcQWD3Aij8GYxlpCsuIrMzQ%3D and https://www.gnu.org/software/emacs/history.html)

Currently, installing with 24.5.1 (and presumably older versions) does this:

```
==> Running tests
Cannot open load file: no such file or directory, map
Error: Tests failed: `emacs --batch -Q --directory /home/bob/tmp/seq-20161207-9119-dj2sn7/seq-2.19 --directory /home/bob/tmp/seq-20161207-9119-dj2sn7/seq-2.19 --directory /home/bob/tmp/seq-20161207-9119-dj2sn7/seq-2.19/tests  -l ert -l tests/seq-tests.el --eval (ert-run-tests-batch-and-exit '(not (tag interactive)))`
ln -s ../../../Cellar/seq/2.19/share/emacs/site-lisp/seq seq
Error: Kernel.exit
```

Note that removing the patch to `(require 'map)` isn't sufficient either:
```
FAILED  22/32  test-seq-random-elt-take-all
```

As there's still a `.el` file for 24.x present, I think this is preferable to requiring 25.1